### PR TITLE
Typo in log output

### DIFF
--- a/whole-house-fan.sa.groovy
+++ b/whole-house-fan.sa.groovy
@@ -76,7 +76,7 @@ def checkThings(evt) {
     }
     
     if(insideTemp < outsideTemp) {
-    	log.debug "Not running due to insideTemp > outdoorTemp"
+    	log.debug "Not running due to insideTemp < outdoorTemp"
     	shouldRun = false;
     }
     


### PR DESCRIPTION
It seems that it should be `<` if the check above, `if(insideTemp < outsideTemp)` is also checking `<`
